### PR TITLE
Store the complete tpmt_signature structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LDLIBS = -lwolftpm -lwolfssl -lm -pthread -lcurl
 
 .PHONY: all
 all:
-	$(CC) $(CFLAGS) -o enact agent.c tpm.c $(LDFLAGS) $(LDLIBS)
+	$(CC) $(CFLAGS) -o enact agent.c tpm.c misc.c $(LDFLAGS) $(LDLIBS)
 
 .PHONY: clean
 clean:

--- a/agent.c
+++ b/agent.c
@@ -386,11 +386,22 @@ int fs_storeSign(ENACT_EVIDENCE *attested)
     retSize = expectedSize = 0;
     fp = XFOPEN(ENACT_SIGNATURE_FILENAME, "wb");
     if(fp != XBADFILE) {
+        /* Store signature and hash algorithm */
+        fileSize = sizeof(attested->signature.sigAlg);
+        expectedSize += fileSize;
+        ret = XFWRITE(&attested->signature.sigAlg, 1, fileSize, fp);
+        retSize += ret;
+
+        fileSize = sizeof(attested->signature.signature.ecdsa.hash);
+        expectedSize += fileSize;
+        ret = XFWRITE(&attested->signature.signature.ecdsa.hash, 1, fileSize, fp);
+        retSize += ret;
+
         /* R part of ECC signature */
         fileSize = sizeof(attested->signature.signature.ecdsa.signatureR.size);
-        expectedSize = fileSize;
-        ret = XFWRITE(&fileSize, 1, fileSize, fp);
-        retSize = ret;
+        expectedSize += fileSize;
+        ret = XFWRITE(&attested->signature.signature.ecdsa.signatureR.size, 1, fileSize, fp);
+        retSize += ret;
 
         buffer = attested->signature.signature.ecdsa.signatureR.buffer;
         fileSize = attested->signature.signature.ecdsa.signatureR.size;
@@ -400,7 +411,7 @@ int fs_storeSign(ENACT_EVIDENCE *attested)
         /* S part of ECC signature */
         fileSize = sizeof(attested->signature.signature.ecdsa.signatureS.size);
         expectedSize += fileSize;
-        ret = XFWRITE(&fileSize, 1, fileSize, fp);
+        ret = XFWRITE(&attested->signature.signature.ecdsa.signatureS.size, 1, fileSize, fp);
         retSize += ret;
 
         buffer = attested->signature.signature.ecdsa.signatureS.buffer;

--- a/agent.c
+++ b/agent.c
@@ -65,7 +65,7 @@ static int read_nodeid(ENACT_EVIDENCE *evidence, const char *filename)
 
     if(evidence != NULL && filename != NULL) {
         XFILE fp = NULL;
-        int len = 0;
+        int len;
 
         fp = XFOPEN(filename, "rb");
         if(fp != XBADFILE) {

--- a/enact.h
+++ b/enact.h
@@ -32,10 +32,13 @@
 #define ENACT_SUCCESS        0
 #define ENACT_ERROR         -1
 #define ENACT_ERROR_START   -2
-#define ENACT_FAILURE       -127
+#define NOT_IMPLEMENTED     -127
 #define BAD_ARG             -128
 
-#define UUID_V4_SIZE 36
+#define UUID_V4_SIZE    36
+#define UUID_V4_CHARS   32
+#define UUID_V4_BYTES   16
+
 #define ENACT_TPM_QUOTE_PCR     23
 #define ENACT_TPM_HANDLE_SRK    0x81010010
 #define ENACT_TPM_HANDLE_AK     0x81010011
@@ -91,6 +94,7 @@ typedef struct ENACT_TPM {
 } ENACT_TPM;
 
 typedef struct ENACT_EVIDENCE {
+    char nodeid[UUID_V4_BYTES];
     TPM2B_ATTEST raw;
     TPMS_ATTEST data;
     TPMT_SIGNATURE signature;

--- a/misc.c
+++ b/misc.c
@@ -1,0 +1,48 @@
+/* misc.c
+ *
+ * Copyright (C) 2018-2021 DesignFirst OU
+ * Copyright (C) 2022 EnactTrust LTD
+ *
+ * This file is part of EnactTrust.
+ *
+ * EnactTrust is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * EnactTrust is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EnactTrust. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+int misc_uuid_str2bin(const char *str, size_t str_size, char *bytes, size_t size)
+{
+    int i, b;
+    char hexstr[3];
+
+    i = b = 0;
+    while(i < str_size)
+    {
+        if(str[i] == '-') {
+            i++;
+            continue;
+        }
+
+        hexstr[0] = str[i++];
+        hexstr[1] = str[i++];
+        hexstr[2] = '\0';
+
+        bytes[b++] = (char)strtol(hexstr, NULL, 16);
+    }
+
+    return b;
+}

--- a/misc.h
+++ b/misc.h
@@ -19,5 +19,17 @@
  * along with EnactTrust.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#ifndef _ENACT_MISC_H_
+#define _ENACT_MISC_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int misc_uuid_str2bin(const char *str, size_t str_size, char *bytes, size_t size);
+
+#ifdef __cplusplus
+    }
+#endif
+
+#endif /* _ENACT_MISC_H_ */

--- a/misc.h
+++ b/misc.h
@@ -1,0 +1,23 @@
+/* misc.h
+ *
+ * Copyright (C) 2018-2021 DesignFirst OU
+ * Copyright (C) 2022 EnactTrust LTD
+ *
+ * This file is part of EnactTrust.
+ *
+ * EnactTrust is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * EnactTrust is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EnactTrust.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+int misc_uuid_str2bin(const char *str, size_t str_size, char *bytes, size_t size);

--- a/tpm.c
+++ b/tpm.c
@@ -364,3 +364,8 @@ int tpm_exportEccPubToPem(ENACT_TPM *tpm, ENACT_PEM *pem, const char *filename)
 
     return ret;
 }
+
+void tpm_printError(int verbose, int ret)
+{
+    if(verbose) printf("TPM error 0x%x: %s\n", ret, TPM2_GetRCString(ret));
+}

--- a/tpm.c
+++ b/tpm.c
@@ -271,7 +271,10 @@ int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *attested)
     quoteCmd.signHandle = tpm->ak.handle.hndl;
     quoteCmd.inScheme.scheme = TPM_ALG_ECDSA;
     quoteCmd.inScheme.details.any.hashAlg = TPM_ALG_SHA256;
-    quoteCmd.qualifyingData.size = 0;
+    quoteCmd.qualifyingData.size = sizeof(attested->nodeid);
+    XMEMCPY((byte*)&quoteCmd.qualifyingData.buffer,
+            (byte*)&attested->nodeid,
+            quoteCmd.qualifyingData.size);
 
     wolfTPM2_SetAuthHandle(&tpm->dev, 0, &tpm->ak.handle);
     TPM2_SetupPCRSel(&quoteCmd.PCRselect, TPM_ALG_SHA256, ENACT_TPM_QUOTE_PCR);

--- a/tpm.h
+++ b/tpm.h
@@ -19,6 +19,12 @@
  * along with EnactTrust.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#ifndef _ENACT_TPM_H_
+#define _ENACT_TPM_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 int tpm_init(ENACT_TPM *tpm);
 int tpm_deinit(ENACT_TPM *tpm);
@@ -36,8 +42,10 @@ int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *attested);
 int tpm_exportEccPubToPem(ENACT_TPM *tpm, ENACT_PEM *pem, const char *filename);
 int tpm_exportRsaPubToPem(ENACT_TPM *tpm, ENACT_PEM *pem, const char *filename);
 
-inline void tpm_printError(int verbose, int ret)
-{
-    if(verbose) printf("TPM error 0x%x: %s\n", ret, TPM2_GetRCString(ret));
-}
+void tpm_printError(int verbose, int ret);
 
+#ifdef __cplusplus
+    }
+#endif
+
+#endif /* _ENACT_TPM_H_ */


### PR DESCRIPTION
Until now, the EnactTrust agent stored only the R and S parts of the TPMT_SIGNATURE structure for simplicity. Moving forward, we store the complete TPMT_SIGNATURE structure to be compliant with the spec and make it easier to have Crypto-agility.

Signed-off-by: Dimitar Tomov <dimi@tpm.dev>