### PR TITLE
Add TPM GPIO support to detect access to the device's physical case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ LDLIBS = -lwolftpm -lwolfssl -lm -pthread -lcurl
 #Debug Level 3
 #CFLAGS += -g -O0 -DDEBUG_PRINTS -DDEBUG_VERBOSE
 
+# Enable TPM GPIO support
+#CFLAGS += -DENACT_TPM_GPIO_ENABLE
+
 .PHONY: all
 all:
 	$(CC) $(CFLAGS) -o enact agent.c tpm.c misc.c $(LDFLAGS) $(LDLIBS)

--- a/agent.c
+++ b/agent.c
@@ -40,15 +40,14 @@ static char nodeid[UUID_V4_SIZE];
  *
  * * Quick start - Basic attestation service for 1 node (this version).
  * * Developer   - Advanced attestation service for 5 nodes.
- * * Team        - Up to 5 Developers, each with 10 nodes.
  * * Enterprise  - Protecting IoT products during their entire lifecycle,
  *                 ZeroTrust security model for critical infrastructure,
  *                 available on premise and as a managed service.
  *
  * Contact us at info@enacttrust.com for more information.
  *
- * Note: Typically, the configuration of EnactTrust Agent application
- *       can be maintained by the EnactTrust Security Cloud, however
+ * Note: Typically, the configuration of the EnactTrust Agent application
+ *       is maintained by the EnactTrust Security Cloud, however
  *       for the purposes of Basic attestation this is not required.
  *
  */
@@ -137,12 +136,14 @@ size_t pem_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-    int i;
-    printf("response body is:\n");
-    for(i=0; i<nmemb; i++) {
-        putchar(ptr[i]);
+    if(verbose) {
+        int i;
+        printf("response body is:\n");
+        for(i=0; i<nmemb; i++) {
+            putchar(ptr[i]);
+        }
+        printf("\n");
     }
-    printf("\n");
     return size * nmemb;
 }
 
@@ -183,14 +184,14 @@ int agent_onboarding(CURL *curl, ENACT_TPM *tpm)
     ret = tpm_exportEccPubToPem(tpm, &pem, ENACT_AKPEM_FILENAME);
     if(ret == TPM_RC_SUCCESS) {
         store_pem(&pem, ENACT_AKPEM_FILENAME);
-        if(verbose) printf("Agent sent onboarding information.\n");
+        if(verbose) printf("AKpub prepared to enroll.\n");
     }
 
     ret = wolfTPM2_RsaKey_TpmToPemPub(&tpm->dev, &tpm->ek, pem.key, &pemSize);
     if(ret == TPM_RC_SUCCESS) {
         pem.size = pemSize;
         store_pem(&pem, ENACT_EKPEM_FILENAME);
-        if(verbose) printf("Agent sent onboarding information.\n");
+        if(verbose) printf("EKpub prepared to enroll.\n");
     }
 
     if(curl) {
@@ -232,7 +233,49 @@ int agent_onboarding(CURL *curl, ENACT_TPM *tpm)
     return ret;
 }
 
-int agent_sentGolden(CURL *curl)
+int agent_sendEkCert(CURL *curl, ENACT_TPM *tpm)
+{
+    int ret = ENACT_ERROR;
+    CURLcode res;
+    curl_mime *form = NULL;
+    curl_mimepart *field = NULL;
+
+    if(curl) {
+        form = curl_mime_init(curl);
+
+        ret = tpm_get_ekcert(tpm, ENACT_EKCERT_FILENAME);
+        if(ret == ENACT_SUCCESS) {
+            if(verbose) printf("EKCert prepared to enroll.\n");
+
+            field = curl_mime_addpart(form);
+            curl_mime_name(field, ENACT_API_PEM_ARG_EKCERT);
+            curl_mime_filedata(field, ENACT_EKCERT_FILENAME);
+
+            field = curl_mime_addpart(form);
+            curl_mime_name(field, ENACT_API_GOLDEN_ARG_NODEID);
+            curl_mime_filedata(field, ENACT_NODEID_TEMPFILE);
+
+            curl_easy_setopt(curl, CURLOPT_URL, URL_BACKEND_NODE_EKCERT);
+            curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
+            curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+
+            res = curl_easy_perform(curl);
+            if(res != CURLE_OK) {
+                fprintf(stderr, "curl_easy_perform() failed: %s\n",
+                        curl_easy_strerror(res));
+            }
+            else {
+                ret = ENACT_SUCCESS;
+            }
+        }
+    }
+
+    curl_easy_reset(curl);
+    curl_mime_free(form);
+    return ret;
+}
+
+int agent_sendGolden(CURL *curl)
 {
     int ret = ENACT_ERROR;
     CURLcode res;
@@ -248,7 +291,7 @@ int agent_sentGolden(CURL *curl)
 
         field = curl_mime_addpart(form);
         curl_mime_name(field, ENACT_API_GOLDEN_ARG_SIGN);
-        curl_mime_filedata(field, ENACT_SIGNATURE_FILENAME);
+        curl_mime_filedata(field, ENACT_QUOTE_SIGNATURE_FILENAME);
 
         field = curl_mime_addpart(form);
         curl_mime_name(field, ENACT_API_GOLDEN_ARG_NODEID);
@@ -273,7 +316,9 @@ int agent_sentGolden(CURL *curl)
     return ret;
 }
 
-int agent_sentEvidence(CURL *curl)
+int agent_sendEvidence(CURL *curl, const char *endpoint,
+                       const char *evidBlob,
+                       const char *signBlob)
 {
     int ret = ENACT_ERROR;
     CURLcode res;
@@ -285,17 +330,17 @@ int agent_sentEvidence(CURL *curl)
 
         field = curl_mime_addpart(form);
         curl_mime_name(field, ENACT_API_EVIDENCE_ARG_EVIDENCE);
-        curl_mime_filedata(field, ENACT_QUOTE_FILENAME);
+        curl_mime_filedata(field, evidBlob);
 
         field = curl_mime_addpart(form);
         curl_mime_name(field, ENACT_API_EVIDENCE_ARG_SIGN);
-        curl_mime_filedata(field, ENACT_SIGNATURE_FILENAME);
+        curl_mime_filedata(field, signBlob);
 
         field = curl_mime_addpart(form);
         curl_mime_name(field, ENACT_API_EVIDENCE_ARG_NODEID);
         curl_mime_filedata(field, ENACT_NODEID_TEMPFILE);
 
-        curl_easy_setopt(curl, CURLOPT_URL, URL_NODE_EVIDENCE);
+        curl_easy_setopt(curl, CURLOPT_URL, endpoint);
         curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
 
@@ -366,14 +411,14 @@ int fs_listFiles(ENACT_FILES *files)
 }
 
 
-int fs_storeQuote(ENACT_EVIDENCE *evidence)
+int fs_storeEvidence(ENACT_EVIDENCE *evidence, const char *filename)
 {
     int ret = ENACT_ERROR;
     int fileSize, retSize, expectedSize;
     FILE *fp;
 
     retSize = expectedSize = 0;
-    fp = XFOPEN(ENACT_QUOTE_FILENAME, "wb");
+    fp = XFOPEN(filename, "wb");
     if(fp != XBADFILE) {
         fileSize = sizeof(evidence->raw.size);
         expectedSize = sizeof(evidence->raw.size);
@@ -400,7 +445,7 @@ int fs_storeQuote(ENACT_EVIDENCE *evidence)
     return ret;
 }
 
-int fs_storeSign(ENACT_EVIDENCE *evidence)
+int fs_storeSign(ENACT_EVIDENCE *evidence, const char *filename)
 {
     UINT16 ret = ENACT_ERROR;
     UINT16 fileSize, retSize, expectedSize;
@@ -408,7 +453,7 @@ int fs_storeSign(ENACT_EVIDENCE *evidence)
     FILE *fp = NULL;
 
     retSize = expectedSize = 0;
-    fp = XFOPEN(ENACT_SIGNATURE_FILENAME, "wb");
+    fp = XFOPEN(filename, "wb");
     if(fp != XBADFILE) {
         /* Store signature and hash algorithm */
         fileSize = sizeof(evidence->signature.sigAlg);
@@ -482,6 +527,13 @@ int EnactAgent(ENACT_EVIDENCE *evidence, ENACT_FILES *files, ENACT_TPM *tpm, int
     if(onboard) {
         /* Send AK & EK PEM for host identification */
         agent_onboarding(curl, tpm);
+#ifdef ENACT_TPM_GPIO_ENABLE
+        /* Configure TPM GPIO for physical lock detection */
+        tpm_gpio_config(tpm, TPM_GPIO_A);
+        tpm_gpio_read(tpm, TPM_GPIO_A);
+#endif /* ENACT_TPM_GPIO_ENABLE */
+        /* Send EK Certificate for TPM Manufacturer identification */
+        agent_sendEkCert(curl, tpm);
     }
     else {
         /* Read nodeID to prepare for use later, in evidence */
@@ -495,6 +547,7 @@ int EnactAgent(ENACT_EVIDENCE *evidence, ENACT_FILES *files, ENACT_TPM *tpm, int
     }
     else {
         printf("Unable to prepare evidence\n");
+        goto exit;
     }
 
     if(ret == ENACT_SUCCESS) {
@@ -505,23 +558,44 @@ int EnactAgent(ENACT_EVIDENCE *evidence, ENACT_FILES *files, ENACT_TPM *tpm, int
     }
     else {
         printf("Unable to create evidence\n");
+        goto exit;
     }
-    /* Store temporary artifacts */
+    /* Store temporary System evidence artifacts */
     if(ret == ENACT_SUCCESS) {
-        printf("Storing quote\n");
-        ret = fs_storeQuote(evidence);
-        printf("Storing signature\n");
-        ret |= fs_storeSign(evidence);
+        if(verbose) printf("Storing System evidence\n");
+        ret = fs_storeEvidence(evidence, ENACT_QUOTE_FILENAME);
+        ret |= fs_storeSign(evidence, ENACT_QUOTE_SIGNATURE_FILENAME);
         if(ret) {
             printf("Failed to store evidence\n");
+            goto exit;
         }
     }
+
+#ifdef ENACT_TPM_GPIO_ENABLE
+    ret = tpm_gpio_certify(tpm, evidence, TPM_GPIO_A);
+    /* Store temporary GPIO evidence artifacts */
+    if(ret == ENACT_SUCCESS) {
+        if(verbose) printf("Storing GPIO evidence\n");
+        ret = fs_storeEvidence(evidence, ENACT_GPIO_FILENAME);
+        ret |= fs_storeSign(evidence, ENACT_GPIO_SIGNATURE_FILENAME);
+        if(ret) {
+            printf("Failed to store evidence\n");
+            goto exit;
+        }
+    }
+#endif /* ENACT_TPM_GPIO_ENABLE */
+
     /* Transfer golden or fresh evidence to the EnactTrust verifier */
     if(onboard) {
-        agent_sentGolden(curl);
+        agent_sendGolden(curl);
     }
     else {
-        agent_sentEvidence(curl);
+        agent_sendEvidence(curl, URL_NODE_EVIDENCE, ENACT_QUOTE_FILENAME,
+                        ENACT_QUOTE_SIGNATURE_FILENAME);
+#ifdef ENACT_TPM_GPIO_ENABLE
+        agent_sendEvidence(curl, URL_NODE_GPIOEVID, ENACT_GPIO_FILENAME,
+                        ENACT_GPIO_SIGNATURE_FILENAME);
+#endif /* ENACT_TPM_GPIO_ENABLE */
     }
 
     if(ret == ENACT_SUCCESS) {
@@ -531,6 +605,7 @@ int EnactAgent(ENACT_EVIDENCE *evidence, ENACT_FILES *files, ENACT_TPM *tpm, int
         printf("Error %d. Please contact us at support@enacttrust.com\n", ret);
     }
 
+exit:
     /* Make sure we do a clean exit */
     if(curl) {
         curl_easy_cleanup(curl);
@@ -569,10 +644,16 @@ int main(int argc, char *argv[])
     XMEMSET(nodeid, 0, sizeof(nodeid));
 
     printf("EnactTrust agent v%s\n", ENACT_VERSION_STRING);
-    printf("EnactTrust endpoints in use\n");
+    printf("\n");
+    printf("EnactTrust endpoints in use:\n");
     printf("Onboarding: %s\n", URL_NODE_PEM);
     printf("Golden value: %s\n", URL_NODE_GOLDEN);
     printf("Fresh evidence: %s\n", URL_NODE_EVIDENCE);
+    printf("EK Cert: %s\n", URL_NODE_EKCERT);
+#ifdef ENACT_TPM_GPIO_ENABLE
+    printf("GPIO evidence: %s\n", URL_NODE_GPIOEVID);
+#endif
+    printf("\n");
 
     /* Parse arguments */
     onboarding = setup = 0;

--- a/agent.c
+++ b/agent.c
@@ -253,7 +253,7 @@ int agent_sendEkCert(CURL *curl, ENACT_TPM *tpm)
 
             field = curl_mime_addpart(form);
             curl_mime_name(field, ENACT_API_GOLDEN_ARG_NODEID);
-            curl_mime_filedata(field, ENACT_NODEID_TEMPFILE);
+            curl_mime_data(field, (const char *)nodeid, sizeof(nodeid));
 
             curl_easy_setopt(curl, CURLOPT_URL, URL_BACKEND_NODE_EKCERT);
             curl_easy_setopt(curl, CURLOPT_MIMEPOST, form);
@@ -617,11 +617,11 @@ exit:
 
 void usage(void) {
     printf("EnactTrust agent has these modes of operation:\n");
-    printf("\t./enact onboard UID - Use to provision a new node\n");
+    printf("\tenact onboard UID - Use to provision a new node\n");
     printf("\t\tUID - Register at www.enacttrust.com for your user id.\n");
-    printf("\t./enact start - EnactTrust is configured as a Linux service\n");
+    printf("\tenact start - EnactTrust is configured as a Linux service\n");
     printf("\t\tThis way Enact can continiously monitor the system health\n");
-    printf("\t./enact - Generate a fresh evidence\n");
+    printf("\tenact - Generate a fresh evidence\n");
     printf("\t\tTypically, the Linux service generates the fresh evidence,\n");
     printf("\t\thowever, enact can be launched on demand for various use cases\n");
     printf("Please contact us at \"support@enacttrust.com\" for more information.\n");
@@ -644,15 +644,6 @@ int main(int argc, char *argv[])
     XMEMSET(nodeid, 0, sizeof(nodeid));
 
     printf("EnactTrust agent v%s\n", ENACT_VERSION_STRING);
-    printf("\n");
-    printf("EnactTrust endpoints in use:\n");
-    printf("Onboarding: %s\n", URL_NODE_PEM);
-    printf("Golden value: %s\n", URL_NODE_GOLDEN);
-    printf("Fresh evidence: %s\n", URL_NODE_EVIDENCE);
-    printf("EK Cert: %s\n", URL_NODE_EKCERT);
-#ifdef ENACT_TPM_GPIO_ENABLE
-    printf("GPIO evidence: %s\n", URL_NODE_GPIOEVID);
-#endif
     printf("\n");
 
     /* Parse arguments */
@@ -680,9 +671,25 @@ int main(int argc, char *argv[])
         if(verbose) printf("Generating fresh evidence.\n");
     }
 
+    printf("EnactTrust endpoints in use:\n");
+    if(onboarding) {
+        printf("Onboarding: %s\n", URL_NODE_PEM);
+        printf("Golden value: %s\n", URL_NODE_GOLDEN);
+        printf("EK Cert: %s\n", URL_NODE_EKCERT);
+    }
+    else {
+        printf("Fresh evidence: %s\n", URL_NODE_EVIDENCE);
+    #ifdef ENACT_TPM_GPIO_ENABLE
+        printf("GPIO evidence: %s\n", URL_NODE_GPIOEVID);
+    #endif
+        printf("\n");
+    }
+
     /* Configure as a service, or execute an action */
     if(setup) {
         printf("Running as a Linux service is not implemented\n");
+        printf("Run enact without arguments to generate a fresh evidence\n");
+        printf("\t$ enact\n\n");
         ret = NOT_IMPLEMENTED; /* TODO */
     }
     else {

--- a/enact.h
+++ b/enact.h
@@ -66,20 +66,24 @@
 #define MAX_PEM_SIZE 512
 #define MAX_CMD_SIZE 200
 
+#ifdef ENACT_TPM_GPIO_ENABLE
 typedef struct ENACT_TPM_GPIO {
     WOLFTPM2_NV nv;
     WOLFTPM2_HANDLE nvParent;
     TPMI_GPIO_MODE gpioMode;
     TPM_HANDLE nvIndex;
 } ENACT_TPM_GPIO;
+#endif /* ENACT_TPM_GPIO_ENABLE */
 
 typedef struct ENACT_TPM {
-    ENACT_TPM_GPIO gpio;
     WOLFTPM2_DEV dev;
     WOLFTPM2_KEY ek;
     WOLFTPM2_KEY primary; /* Storage Key */
     WOLFTPM2_KEY ak; /* Attestation Key */
     WOLFTPM2_SESSION sessionA; /* Param Enc */
+#ifdef ENACT_TPM_GPIO_ENABLE
+    ENACT_TPM_GPIO gpio;
+#endif
 } ENACT_TPM;
 
 typedef struct ENACT_EVIDENCE {

--- a/enact.h
+++ b/enact.h
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ * along with EnactTrust.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef _ENACT_H_
@@ -29,8 +29,8 @@
     extern "C" {
 #endif
 
-#define ENACT_VERSION_STRING "0.5.0"
-#define ENACT_VERSION_HEX 0x00005000
+#define ENACT_VERSION_STRING "0.6.0"
+#define ENACT_VERSION_HEX 0x00006000
 
 /* Return codes */
 #define ENACT_SUCCESS        0
@@ -46,15 +46,19 @@
 #define ENACT_TPM_QUOTE_PCR     23
 #define ENACT_TPM_HANDLE_SRK    0x81010010
 #define ENACT_TPM_HANDLE_AK     0x81010011
+#define ENACT_TPM_HANDLE_NVRAM  0x0180020A
 
 #define ENACT_QUOTE_FILENAME "evidence.blob\0"
+#define ENACT_QUOTE_SIGNATURE_FILENAME "signature.blob\0"
+#define ENACT_GPIO_FILENAME "gpio.blob\0"
+#define ENACT_GPIO_SIGNATURE_FILENAME "gpiosign.blob\0"
 #define ENACT_AKRAW_FILENAME "ak.pub\0"
 #define ENACT_AKPEM_FILENAME "ak.pem\0"
 #define ENACT_EKRAW_FILENAME "ek.pub\0"
 #define ENACT_EKPEM_FILENAME "ek.pem\0"
-#define ENACT_SIGNATURE_FILENAME "signature.blob\0"
+#define ENACT_EKCERT_FILENAME "ek.cert\0"
 #define ENACT_NODEID_TEMPFILE "node.id\0"
-#define ENACT_DEMO_PATH "../demo/\0"    /* Quick start protects this folder */
+#define ENACT_DEMO_PATH "/demo/\0"    /* Quick start protects this folder */
 #define ENACT_DEMO_FILE "/etc/passwd\0" /* Protect the Linux password file */
 
 #define MAX_FILE_COUNT 20
@@ -62,7 +66,15 @@
 #define MAX_PEM_SIZE 512
 #define MAX_CMD_SIZE 200
 
+typedef struct ENACT_TPM_GPIO {
+    WOLFTPM2_NV nv;
+    WOLFTPM2_HANDLE nvParent;
+    TPMI_GPIO_MODE gpioMode;
+    TPM_HANDLE nvIndex;
+} ENACT_TPM_GPIO;
+
 typedef struct ENACT_TPM {
+    ENACT_TPM_GPIO gpio;
     WOLFTPM2_DEV dev;
     WOLFTPM2_KEY ek;
     WOLFTPM2_KEY primary; /* Storage Key */

--- a/enact_api.h
+++ b/enact_api.h
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ * along with EnactTrust.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef _ENACT_API_H_
@@ -31,10 +31,13 @@
 #define ENACT_API_SECRET    "node/secret"
 #define ENACT_API_GOLDEN    "node/golden"
 #define ENACT_API_EVIDENCE  "node/evidence"
+#define ENACT_API_EKCERT    "node/tpmekcert"
+#define ENACT_API_GPIOEVID  "node/tpmgpio"
 
 #define ENACT_API_PEM_ARG_AK    "ak_pub"
 #define ENACT_API_PEM_ARG_EK    "ek_pub"
 #define ENACT_API_PEM_ARG_AKNAME "ak_name"
+#define ENACT_API_PEM_ARG_EKCERT "ek_cert"
 #define ENACT_API_PEM_ARG_UID   "user_id"
 
 #define ENACT_API_GOLDEN_ARG_GOLDEN "golden_blob"
@@ -55,10 +58,18 @@
 #define URL_BACKEND_NODE_PEM        ENACT_BACKEND ENACT_API_PEM
 #define URL_BACKEND_NODE_GOLDEN     ENACT_BACKEND ENACT_API_GOLDEN
 #define URL_BACKEND_NODE_EVIDENCE   ENACT_BACKEND ENACT_API_EVIDENCE
+#define URL_BACKEND_NODE_EKCERT     ENACT_BACKEND ENACT_API_EKCERT
+#define URL_BACKEND_NODE_GPIOEVID   ENACT_BACKEND ENACT_API_GPIOEVID
 
 /* Endpoints in use */
 #define URL_NODE_PEM        URL_BACKEND_NODE_PEM
 #define URL_NODE_GOLDEN     URL_BACKEND_NODE_GOLDEN
 #define URL_NODE_EVIDENCE   URL_BACKEND_NODE_EVIDENCE
+#define URL_NODE_EKCERT     URL_BACKEND_NODE_EKCERT
+#define URL_NODE_GPIOEVID   URL_BACKEND_NODE_GPIOEVID
+
+#ifdef __cplusplus
+    }
+#endif
 
 #endif /* _ENACT_API_H_ */

--- a/tpm.c
+++ b/tpm.c
@@ -283,7 +283,10 @@ int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *attested)
             (byte*)&attested->nodeid,
             quoteCmd.qualifyingData.size);
 
-    wolfTPM2_SetAuthHandle(&tpm->dev, 0, &tpm->ak.handle);
+    wolfTPM2_SetAuthPassword(&tpm->dev, 0, NULL);
+    wolfTPM2_UnsetAuth(&tpm->dev, 1);
+    wolfTPM2_UnsetAuth(&tpm->dev, 2);
+
     TPM2_SetupPCRSel(&quoteCmd.PCRselect, TPM_ALG_SHA256, ENACT_TPM_QUOTE_PCR);
     ret = TPM2_Quote(&quoteCmd, &quoteResp);
     if(ret == TPM_RC_SUCCESS) {
@@ -525,8 +528,9 @@ int tpm_gpio_certify(ENACT_TPM *tpm, ENACT_EVIDENCE *attested, int gpio)
     nvCmd.offset = 0;
     nvCmd.size = 1; /* GPIO status is provided as a single byte */
 
-    wolfTPM2_SetAuthHandle(&tpm->dev, 0, &tpm->ak.handle);
+    wolfTPM2_SetAuthPassword(&tpm->dev, 0, NULL);
     wolfTPM2_SetAuthPassword(&tpm->dev, 1, NULL);
+    wolfTPM2_UnsetAuth(&tpm->dev, 2);
 
     ret = TPM2_NV_Certify(&nvCmd, &nvResp);
     if(ret == TPM_RC_SUCCESS) {

--- a/tpm.h
+++ b/tpm.h
@@ -39,14 +39,14 @@ int tpm_pcrReset(UINT32 pcrIndex);
 int tpm_pcrRead(ENACT_EVIDENCE *tpm, UINT32 pcrIndex);
 int tpm_pcrExtend(ENACT_FILES *files, UINT32 pcrIndex);
 
-int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *attested);
+int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *evidence);
 
 int tpm_exportEccPubToPem(ENACT_TPM *tpm, ENACT_PEM *pem, const char *filename);
 int tpm_exportRsaPubToPem(ENACT_TPM *tpm, ENACT_PEM *pem, const char *filename);
 
 int tpm_gpio_config(ENACT_TPM *tpm, int gpio);
 int tpm_gpio_read(ENACT_TPM *tpm, int gpio);
-int tpm_gpio_certify(ENACT_TPM *tpm, ENACT_EVIDENCE *attested, int gpio);
+int tpm_gpio_certify(ENACT_TPM *tpm, ENACT_EVIDENCE *evidence, int gpio);
 
 int tpm_get_ekcert(ENACT_TPM *tpm, const char *filename);
 int tpm_get_property(ENACT_TPM *tpm, UINT32 tag, UINT32 *value);

--- a/tpm.h
+++ b/tpm.h
@@ -26,6 +26,8 @@
     extern "C" {
 #endif
 
+void tpm_printError(int verbose, int ret);
+
 int tpm_init(ENACT_TPM *tpm);
 int tpm_deinit(ENACT_TPM *tpm);
 
@@ -42,7 +44,12 @@ int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *attested);
 int tpm_exportEccPubToPem(ENACT_TPM *tpm, ENACT_PEM *pem, const char *filename);
 int tpm_exportRsaPubToPem(ENACT_TPM *tpm, ENACT_PEM *pem, const char *filename);
 
-void tpm_printError(int verbose, int ret);
+int tpm_gpio_config(ENACT_TPM *tpm, int gpio);
+int tpm_gpio_read(ENACT_TPM *tpm, int gpio);
+int tpm_gpio_certify(ENACT_TPM *tpm, ENACT_EVIDENCE *attested, int gpio);
+
+int tpm_get_ekcert(ENACT_TPM *tpm, const char *filename);
+int tpm_get_property(ENACT_TPM *tpm, UINT32 tag, UINT32 *value);
 
 #ifdef __cplusplus
     }


### PR DESCRIPTION
This PR adds two features:

- Add TPM GPIO evidence to detect access to the device's physical case
- Enable enrollment of the EK Certificate
- Style: rename attested to evidence in tpm.c

Signed-off-by: Dimitar Tomov <dimi@tpm.dev>