### PR TITLE
Add golden gpio evidence

### DIFF
--- a/agent.c
+++ b/agent.c
@@ -572,6 +572,9 @@ int EnactAgent(ENACT_EVIDENCE *evidence, ENACT_FILES *files, ENACT_TPM *tpm, int
     }
 
 #ifdef ENACT_TPM_GPIO_ENABLE
+    /* Get a fresh readout of the GPIO in the TPM NV Index */
+    tpm_gpio_read(tpm, TPM_GPIO_A);
+    /* Generate TPM GPIO evidence */
     ret = tpm_gpio_certify(tpm, evidence, TPM_GPIO_A);
     /* Store temporary GPIO evidence artifacts */
     if(ret == ENACT_SUCCESS) {
@@ -592,11 +595,11 @@ int EnactAgent(ENACT_EVIDENCE *evidence, ENACT_FILES *files, ENACT_TPM *tpm, int
     else {
         agent_sendEvidence(curl, URL_NODE_EVIDENCE, ENACT_QUOTE_FILENAME,
                         ENACT_QUOTE_SIGNATURE_FILENAME);
+    }
 #ifdef ENACT_TPM_GPIO_ENABLE
-        agent_sendEvidence(curl, URL_NODE_GPIOEVID, ENACT_GPIO_FILENAME,
+    agent_sendEvidence(curl, URL_NODE_GPIOEVID, ENACT_GPIO_FILENAME,
                         ENACT_GPIO_SIGNATURE_FILENAME);
 #endif /* ENACT_TPM_GPIO_ENABLE */
-    }
 
     if(ret == ENACT_SUCCESS) {
         printf("OK. Evidence created and sent. No action required.\n");

--- a/agent.c
+++ b/agent.c
@@ -369,7 +369,7 @@ int fs_listFiles(ENACT_FILES *files)
 
     d = opendir(ENACT_DEMO_PATH);
     if(d != NULL) {
-        if(verbose) printf("Listing all files in current directory\n");
+        printf("Protecting folder %s\n", ENACT_DEMO_PATH);
         for(i = 0; i < MAX_FILE_COUNT; i++) {
             dir = readdir(d);
             if(dir == NULL) {
@@ -390,7 +390,7 @@ int fs_listFiles(ENACT_FILES *files)
         }
     }
     else {
-        if(verbose) printf("Unable to open directory. Protecting /etc/passwd\n");
+        printf("Protecting file %s\n", ENACT_DEMO_FILE);
         /* Special case: protect Linux user list */
         strncpy(files->name[0], ENACT_DEMO_FILE, sizeof(files->name[0]));
         files->count++;

--- a/enact.h
+++ b/enact.h
@@ -29,8 +29,8 @@
     extern "C" {
 #endif
 
-#define ENACT_VERSION_STRING "0.6.0"
-#define ENACT_VERSION_HEX 0x00006000
+#define ENACT_VERSION_STRING "0.6.5"
+#define ENACT_VERSION_HEX 0x00006050
 
 /* Return codes */
 #define ENACT_SUCCESS        0


### PR DESCRIPTION
This PR makes two important changes:

* Add a missing GPIO golden value during onboarding
* Add missing GPIO readout before NV Certify
* Bump agent version to 0.6.5

