### PR TITLE
Add the node's hostname to Enact onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Note: EnactTrust is meant to run in a memory isolated environment, so it can pro
 
 Here is the complete list of EnactTrust versions:
 
-*   Quick start - Basic attestation for 1 node (this version).
-*   Developer - Advanced attestation for 5 nodes.
-*   Enterprise - Protecting IoT products during their entire lifecycle, ZeroTrust security model for critical infrastructure, available on premise and as a managed service, EnactTrust agent deployed in memory isolation to protect the system even in the case of an attack.
+- Quick start - Basic attestation for 1 node (this version).
+- Developer - Advanced attestation for 5 nodes.
+- Enterprise - Protecting IoT products during their entire lifecycle, ZeroTrust security model for critical infrastructure, available on premise and as a managed service, EnactTrust agent deployed in memory isolation to protect the system even in the case of an attack.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ If you're familiar with attestation and are comfortable with looking at C code, 
 
 ## Requirements
 
-EnactTrust is built for the *IoT & Edge devices* that live in the field for 3/5/10 years, therefore our implementation is highly portable.
-
-EnactTrust supports the most popular firmware architectures and the major RTOS solutions, including FreeRTOS, Zephyr and others:
+EnactTrust is built for the *IoT & Edge devices* that live in the field for 3/5/10 years, therefore our implementation is highly portable and EnactTrust supports the most popular firmware architectures. Including the major RTOS solutions, like FreeRTOS, Zephyr and others:
 
 | Architecture          | EnactTrust   | QuickStart   |
 | --------------------- | ------------ | ------------ |

--- a/README.md
+++ b/README.md
@@ -27,18 +27,13 @@ Please check the [INSTALL.md](INSTALL.md) file for step by step instructions. Sh
 1. enact onboard A3S_USER_ID (see above step)
 1. enact
 
-If you're familiar with attesattino and are comfortable with looking at C code, you can also try out the [**EnactTrust API**](enact-api.c) which is aimed primarily at 3rd party integrations.
+If you're familiar with attestation and are comfortable with looking at C code, you can also try out the [**EnactTrust API**](enact-api.c) which is aimed primarily at 3rd party integrations.
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/6129df878b364f9ca7c09d72ffe852bf)](https://www.codacy.com/gh/EnactTrust/enact/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=EnactTrust/enact&amp;utm_campaign=Badge_Grade)
 
 ## Requirements
 
-EnactTrust is built for the *IoT & Edge devices* that live in the field for 3/5/10 years, therefore our implementation is highly portable. This includes:
-* Industrial IoT
-* Edge gateways
-* Automotive IoT
-* Infrastructure IoT
-* many others
+EnactTrust is built for the *IoT & Edge devices* that live in the field for 3/5/10 years, therefore our implementation is highly portable.
 
 EnactTrust supports the most popular firmware architectures and the major RTOS solutions, including FreeRTOS, Zephyr and others:
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,67 @@
-# EnactTrust agent
+<h1><a href="https://www.enacttrust.com/">
+  <img src="https://blog.enacttrust.com/assets/images/logo/enact-logo.png" width="75px" style="vertical-align:middle" style="float:left">
+</a>EnactTrust</h1> 
 
-_Open-source software that enables you to monitor the health of your system_
+# Security and compliance for IoT & Edge systems
 
-## How it works
+Typical use cases are:
+- offline protection of IoT devices in the field
+- monitoring of the device health of Edge devices
+- compliance for Industrial IoT and Automotive systems
 
-EnactTrust has two components, the Enact agent application(this software) and a Security Cloud.
+To learn more about EnactTrust, [read our **whitepaper**](https://enact-public.s3.eu-west-1.amazonaws.com/STMicroelectronics+-+EnactTrust+-+Whitepaper+-+Embedded+World+2022.pdf).
 
-*   The open source agent generates fresh evidence about the device and system health.
-*   The EnactTrust Security Cloud processes the evidence and verifies the system health is good or bad.
-*   The current health of any node protected by EnactTrust can be monitored using the Web Dashboad of the EnactTrust Security Cloud.
+## Screenshots
 
-Note: The process of providing evidence about the system health is called attestation.
+<a href="https://www.enacttrust.com/ew2022"><img alt="Boing Boing" src="https://uploads-ssl.webflow.com/62ac647209e552092604784f/62af56eae7ad8f51ef298187_enact-dashboard-ew2022.png"></a>
 
-### EnactTrust removes the high R&D cost and breaks the know-how barrier
+Explore device health by visiting the [EnactTrust Security Cloud](https://a3s.enacttrust.com).
 
-Until today, this technology has been leveraged only by large enterprise. Now, thanks to EnactTrust, everyone can use attestation technology to improve their system security.
+## Installation
+
+Please check the [INSTALL.md](INSTALL.md) file for step by step instructions. Short summary is available below:
+
+1. Git clone this repo
+1. Make
+1. Register at https://a3s.enacttrust.com 
+1. enact onboard A3S_USER_ID (see above step)
+1. enact
+
+If you're familiar with attesattino and are comfortable with looking at C code, you can also try out the [**EnactTrust API**](enact-api.c) which is aimed primarily at 3rd party integrations.
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/6129df878b364f9ca7c09d72ffe852bf)](https://www.codacy.com/gh/EnactTrust/enact/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=EnactTrust/enact&amp;utm_campaign=Badge_Grade)
 
-### Installation
+## Requirements
 
-Please check the INSTALL.md file for step by step instructions.
+EnactTrust is built for the *IoT & Edge devices* that live in the field for 3/5/10 years, therefore our implementation is highly portable. This includes:
+* Industrial IoT
+* Edge gateways
+* Automotive IoT
+* Infrastructure IoT
+* many others
+
+EnactTrust supports the most popular firmware architectures and the major RTOS solutions, including FreeRTOS, Zephyr and others:
+
+| Architecture          | EnactTrust   | QuickStart   |
+| --------------------- | ------------ | ------------ |
+| RTOS                  | Yes          |              |
+| Bare-metal            | Yes          |              |
+| Safety-critical (FSM) | Yes          |              |
+| Linux                 | Yes          | Yes          |
+
+Additionally, we aim to support hardware hardening technologies like TrustZone (TF-M & TF-A).
+
+## Built With
+
+The QuickStart version of EnactTrust uses:
+- [wolfTPM](https://github.com/wolfssl/wolfTPM) &mdash; Our QuickStart version uses wolfTPM because it is designed for embedded systems and requires no external dependencies.
+- [libcurl](https://github.com/curl/curl) &mdash; Our agent uses Curl to communicate easily with our cloud server.
+
+Let us know if you want access to our **TF-M** and TF-A variant of EnactTrust by sending us an [email](mailto:info@enacttrust.com).
 
 ## Tiers
 
-This version of EnactTrust is called "Quick Start" and is designed toward ease of use. Run the Enact agent and experience the benefits of Trusted Computing.
+This version of EnactTrust is called "Quick Start" and is designed toward ease of use.
 
 Note: EnactTrust is meant to run in a memory isolated environment, so it can protect your system even when your device is compromised or under attack.
 
@@ -44,4 +81,6 @@ The current "Quick Start" version of EnactTrust is re-written to use the open-so
 
 ## Contact us
 
-Send us an [email](mailto:support@enacttrust.com "contact us over email") with your questions and we will respond. The goal of [EnactTrust](https://www.enacttrust.com "EnactTrust website") is to lower the barrier to building trust into computer systems. Alternatively, you could also post a question in the [TPM.dev](https://www.tpm.dev "TPM.dev community forum") forum.
+The goal of [EnactTrust](https://www.enacttrust.com "EnactTrust website") is to make IoT and Edge systems more secure. Send us an [email](mailto:support@enacttrust.com "contact us over email") with your questions and we will respond. Alternatively, you could also use [TPM.dev](https://www.tpm.dev "TPM.dev community forum") forum. 
+
+We look forward to receiving your comments and questions.

--- a/agent.c
+++ b/agent.c
@@ -369,7 +369,7 @@ int fs_listFiles(ENACT_FILES *files)
 
     d = opendir(ENACT_DEMO_PATH);
     if(d != NULL) {
-        printf("Protecting folder %s\n", ENACT_DEMO_PATH);
+        if(verbose) printf("Protecting folder %s\n", ENACT_DEMO_PATH);
         for(i = 0; i < MAX_FILE_COUNT; i++) {
             dir = readdir(d);
             if(dir == NULL) {
@@ -390,17 +390,15 @@ int fs_listFiles(ENACT_FILES *files)
         }
     }
     else {
-        printf("Protecting file %s\n", ENACT_DEMO_FILE);
+        if(verbose) printf("Protecting file %s\n", ENACT_DEMO_FILE);
         /* Special case: protect Linux user list */
-        strncpy(files->name[0], ENACT_DEMO_FILE, sizeof(files->name[0]));
+        strncpy(files->name[files->count], ENACT_DEMO_FILE, sizeof(files->name[files->count]));
         files->count++;
     }
 
-    if(verbose) {
-        printf("List of regular files(%d):\n", files->count);
-        for(int i = 0; i < files->count; i++) {
-           printf("%s \n", files->name[i]);
-        }
+    printf("List of protected files(%d):\n", files->count);
+    for(int i = 0; i < files->count; i++) {
+        printf("%s \n", files->name[i]);
     }
 
     if(files->count > 0) {
@@ -602,10 +600,10 @@ int EnactAgent(ENACT_EVIDENCE *evidence, ENACT_FILES *files, ENACT_TPM *tpm, int
 #endif /* ENACT_TPM_GPIO_ENABLE */
 
     if(ret == ENACT_SUCCESS) {
-        printf("OK. Evidence created and sent. No action required.\n");
+        printf("\nOK. Evidence created and sent. No action required.\n");
     }
     else {
-        printf("Error %d. Please contact us at support@enacttrust.com\n", ret);
+        printf("\nError %d. Please contact us at support@enacttrust.com\n", ret);
     }
 
 exit:

--- a/enact.h
+++ b/enact.h
@@ -29,8 +29,8 @@
     extern "C" {
 #endif
 
-#define ENACT_VERSION_STRING "0.6.5"
-#define ENACT_VERSION_HEX 0x00006050
+#define ENACT_VERSION_STRING "0.6.7"
+#define ENACT_VERSION_HEX 0x00006070
 
 /* Return codes */
 #define ENACT_SUCCESS        0

--- a/enact_api.h
+++ b/enact_api.h
@@ -39,6 +39,7 @@
 #define ENACT_API_PEM_ARG_AKNAME "ak_name"
 #define ENACT_API_PEM_ARG_EKCERT "ek_cert"
 #define ENACT_API_PEM_ARG_UID   "user_id"
+#define ENACT_API_PEM_ARG_HOSTNAME "hostname"
 
 #define ENACT_API_GOLDEN_ARG_GOLDEN "golden_blob"
 #define ENACT_API_GOLDEN_ARG_SIGN   "signature_blob"


### PR DESCRIPTION
This PR improves the user experience. Enact identifies protected nodes using a unique cryptographic keypair. Now, to make the EnactTruts dashboard more user friendly, the Enact agent sends also the node's hostname as part of the onboarding process.