### PR TITLE
Add integration with veraison 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 # Security and compliance for IoT & Edge systems
 
 Typical use cases are:
-- offline protection of IoT devices in the field
+- protection of IoT devices in the field (including offline)
 - monitoring of the device health of Edge devices
-- compliance for Industrial IoT and Automotive systems
+- compliance with IEC 62443 for Industrial IoT systems
 
 To learn more about EnactTrust, [read our **whitepaper**](https://enact-public.s3.eu-west-1.amazonaws.com/STMicroelectronics+-+EnactTrust+-+Whitepaper+-+Embedded+World+2022.pdf).
 

--- a/enact.h
+++ b/enact.h
@@ -88,6 +88,7 @@ typedef struct ENACT_TPM {
 
 typedef struct ENACT_EVIDENCE {
     char nodeid[UUID_V4_BYTES];
+    char nonce[ENACT_NONCE_SIZE]
     TPM2B_ATTEST raw;
     TPMS_ATTEST data;
     TPMT_SIGNATURE signature;

--- a/tpm.c
+++ b/tpm.c
@@ -278,10 +278,15 @@ int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *evidence)
     quoteCmd.signHandle = tpm->ak.handle.hndl;
     quoteCmd.inScheme.scheme = TPM_ALG_ECDSA;
     quoteCmd.inScheme.details.any.hashAlg = TPM_ALG_SHA256;
-    quoteCmd.qualifyingData.size = sizeof(evidence->nodeid);
+    quoteCmd.qualifyingData.size = sizeof(evidence->nodeid) + ENACT_NONCE_SIZE;
+    /* Prepare nonce */
     XMEMCPY((byte*)&quoteCmd.qualifyingData.buffer,
+            (byte*)&evidence->nonce,
+            ENACT_NONCE_SIZE);
+    /* Prepare nodeid */
+    XMEMCPY((byte*)&quoteCmd.qualifyingData.buffer[ENACT_NONCE_SIZE],
             (byte*)&evidence->nodeid,
-            quoteCmd.qualifyingData.size);
+            sizeof(evidence->nodeid);
 
     wolfTPM2_SetAuthPassword(&tpm->dev, 0, NULL);
     wolfTPM2_UnsetAuth(&tpm->dev, 1);
@@ -519,10 +524,15 @@ int tpm_gpio_certify(ENACT_TPM *tpm, ENACT_EVIDENCE *evidence, int gpio)
     nvCmd.signHandle = tpm->ak.handle.hndl;
     nvCmd.authHandle = tpm->gpio.nvParent.hndl;
     nvCmd.nvIndex = tpm->gpio.nvIndex;
-    nvCmd.qualifyingData.size = sizeof(evidence->nodeid);
+    nvCmd.qualifyingData.size = sizeof(evidence->nodeid) + ENACT_NONCE_SIZE;
+    /* Prepare nonce */
     XMEMCPY((byte*)&nvCmd.qualifyingData.buffer,
+            (byte*)&evidence->nonce,
+            ENACT_NONCE_SIZE);
+    /* Prepare nodeid */
+    XMEMCPY((byte*)&quoteCmd.qualifyingData.buffer[ENACT_NONCE_SIZE],
             (byte*)&evidence->nodeid,
-            nvCmd.qualifyingData.size);
+            sizeof(evidence->nodeid);
     nvCmd.inScheme.scheme = TPM_ALG_ECDSA;
     nvCmd.inScheme.details.any.hashAlg = TPM_ALG_SHA256;
     nvCmd.offset = 0;


### PR DESCRIPTION
This PR does two major changes:

1. Completes the integration with `ARM's Confidential Compute Architecture
2. Enables advanced attestation for every `Quick Start` user of EnactTrust [A3S](https://a3s.enacttrust.com)

