### PR TITLE
Fix PCR selection in quote generation.

### DIFF
--- a/tpm.c
+++ b/tpm.c
@@ -281,6 +281,7 @@ int tpm_createQuote(ENACT_TPM *tpm, ENACT_EVIDENCE *evidence)
         return BAD_ARG;
     }
 
+    memset(&quoteCmd, 0, sizeof(Quote_In));
     quoteCmd.signHandle = tpm->ak.handle.hndl;
     quoteCmd.inScheme.scheme = TPM_ALG_ECDSA;
     quoteCmd.inScheme.details.any.hashAlg = TPM_ALG_SHA256;


### PR DESCRIPTION
Quote_In struct was not being zeroed, resulting in an indeterminate starting state. It's fields were then individually set to ensure correct configuration before obtaining the quote. However, TPM2_SetupPCRSel that is used to configure PCR selection only sets up the selection for the relevant index, and does not touch the other indices. This resulted in random PRCs being "selected" in addition to the one explicitly set.

Zero Quote_In before populating it to avoid this issue.