### PR TITLE
Make user id optional for Veraison

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
   <img src="https://blog.enacttrust.com/assets/images/logo/enact-logo.png" width="75px" style="vertical-align:middle" style="float:left">
 </a>EnactTrust</h1>
 
-EnactTrust is a driver to interact with TPM2 devices on IoT devices.
-EnactTrust facilities doing Remote Attestation ProceedureS (RATS, see RFC9334) by collecting Evidence about the state of a device, and relaying that Evidence to a Verifier operated by the device owner, or by EnactTrust.
+EnactTrust performs remote health checks of a device, by collecting Evidence about the state of the device and relaying that Evidence to a Verifier operated by the device owner, or by EnactTrust.
+
+Note: See Remote Attestation ProceedureS (RATS, see RFC9334). EnactTrust enables IoT devices to use TPM2 (Trusted Platform Module 2.0).
 
 # Security and compliance for IoT & Edge systems
 
@@ -11,6 +12,7 @@ Typical use cases are:
 - protection of IoT devices in the field (including offline)
 - monitoring of the device health of Edge devices
 - compliance with IEC 62443 for Industrial IoT systems
+- driver to interact with TPM2 on IoT devices
 
 To learn more about EnactTrust, [read our **whitepaper**](https://enact-public.s3.eu-west-1.amazonaws.com/STMicroelectronics+-+EnactTrust+-+Whitepaper+-+Embedded+World+2022.pdf).
 

--- a/enact_api.h
+++ b/enact_api.h
@@ -38,7 +38,7 @@
 #define ENACT_API_PEM_ARG_EK    "ek_pub"
 #define ENACT_API_PEM_ARG_AKNAME "ak_name"
 #define ENACT_API_PEM_ARG_EKCERT "ek_cert"
-#define ENACT_API_PEM_ARG_UID   "user_id"
+#define ENACT_API_PEM_ARG_USERID   "user_id"
 #define ENACT_API_PEM_ARG_HOSTNAME "hostname"
 
 #define ENACT_API_GOLDEN_ARG_GOLDEN "golden_blob"


### PR DESCRIPTION
This PR makes the user id optional for Veraison. 

User id is now mandatory only when using the EnactTrust Attestation Service at https://a3s.enacttrust.com

@setrofim please review